### PR TITLE
no extension able to load the configuration for "parameters"

### DIFF
--- a/config/parameters.php
+++ b/config/parameters.php
@@ -28,9 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters->set('env(JWT_PASSPHRASE)', '2adb39303a2d4d4b912047562ffa151645fdd0c04da0f83c9742830aebc7214f');
     if ('prod' === $containerConfigurator->env()) {
-        $containerConfigurator->extension('parameters', [
-            '.container.dumper.inline_factories' => true,
-            '.container.dumper.inline_class_loader' => true,
-        ]);
+        $parameters->set('.container.dumper.inline_factories', true);
+        $parameters->set('.container.dumper.inline_class_loader', true);
     }
 };


### PR DESCRIPTION
when use composer install --no-dev --optimize-autoloader  a message appear . There is no extension able to load the configuration for "parameters" message appear after cache clear